### PR TITLE
[bash] Apply updated symlink paths

### DIFF
--- a/config/bash/bash_setup_common.bash
+++ b/config/bash/bash_setup_common.bash
@@ -30,8 +30,8 @@ androidpic_mv() {
 
 # 3/3/2014 to include rm_dropbox_conflictfiles.bash
 #export PATH=~/data/Dropbox/pg/Lateeye/bashapp:$PATH
-export PATH=~/link/github_repos/130s/hut_10sqft/script:$PATH
-export PYTHONPATH=~/link/github_repos/130s/hut_10sqft/src:$PYTHONPATH
+export PATH=~/link/git_repos/130s/hut_10sqft/script:$PATH
+export PYTHONPATH=~/link/git_repos/130s/hut_10sqft/src:$PYTHONPATH
 
 # 6/9/2016 Workaround for tmux issue https://github.com/130s/hut_10sqft/issues/3
 export DISPLAY=:0

--- a/config/bash/bashrc_130s-kudu1
+++ b/config/bash/bashrc_130s-kudu1
@@ -1,2 +1,2 @@
 # This line needs to be absolute path.
-source ~/link/github_repos/130s/hut_10sqft/config/bash/rc_130s-kudu1.bash
+source ~/link/git_repos/130s/hut_10sqft/config/bash/rc_130s-kudu1.bash

--- a/config/bash/bashrc_130s-p50
+++ b/config/bash/bashrc_130s-p50
@@ -1,2 +1,2 @@
 # This line needs to be absolute path.
-source ~/link/github_repos/130s/hut_10sqft/config/bash/rc_130s-p50.bash
+source ~/link/git_repos/130s/hut_10sqft/config/bash/rc_130s-p50.bash

--- a/config/bash/bashrc_130s-serval
+++ b/config/bash/bashrc_130s-serval
@@ -1,2 +1,2 @@
 # This line needs to be absolute path.
-source ~/link/github_repos/130s/hut_10sqft/config/bash/rc_130s-serval.bash
+source ~/link/git_repos/130s/hut_10sqft/config/bash/rc_130s-serval.bash

--- a/config/bash/bashrc_130s-t440s
+++ b/config/bash/bashrc_130s-t440s
@@ -1,2 +1,2 @@
 # This line needs to be absolute path.
-source ~/link/github_repos/130s/hut_10sqft/config/bash/rc_t440s.bash
+source ~/link/git_repos/130s/hut_10sqft/config/bash/rc_t440s.bash

--- a/config/dot_tmux.conf
+++ b/config/dot_tmux.conf
@@ -1,2 +1,2 @@
 # This file is supposed to be located at ~/.tmux.conf on each OS.
-source-file ~/link/github_repos/130s/hut_10sqft/config/tmux_default.conf
+source-file ~/link/git_repos/130s/hut_10sqft/config/tmux_default.conf

--- a/config/emacs/130s-mac1-win8.el
+++ b/config/emacs/130s-mac1-win8.el
@@ -1,7 +1,7 @@
 ; .emacs specific for 130s-serval
 
 ;; 3/8/2014 Common emacs setting.
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs.el")
 
 (set-frame-height (selected-frame) 58)
 (set-frame-width (selected-frame) 110)

--- a/config/emacs/emacs_130s-kudu1.el
+++ b/config/emacs/emacs_130s-kudu1.el
@@ -2,7 +2,7 @@
 
 ; 2/8/2013 Ubuntu common setting ported
 ; 6/8/2016 Moved dir to the one in git repo.
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
 
 ;; Issue where texts are not shown with emacs -nw option is solved by using "when window-system"
 ;; https://www.emacswiki.org/emacs/FrameSize

--- a/config/emacs/emacs_130s-mac1.el
+++ b/config/emacs/emacs_130s-mac1.el
@@ -1,5 +1,5 @@
 ;; 6/9/2016 Common config read here.
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs.el")
 
 ; 4/6/2012/emacs tex live config
 (server-start)

--- a/config/emacs/emacs_130s-mac1_12.04_vm.el
+++ b/config/emacs/emacs_130s-mac1_12.04_vm.el
@@ -1,8 +1,8 @@
 ; .emacs specific for 130s-serval
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_precise.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_precise.el")
 
 (set-frame-height (selected-frame) 44)
 (set-frame-width (selected-frame) 90)

--- a/config/emacs/emacs_130s-serval.el
+++ b/config/emacs/emacs_130s-serval.el
@@ -1,7 +1,7 @@
 ; .emacs specific for 130s-serval
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
 
 ; 4/6/2012/emacs tex live config
 ; 20170818 Comment out since this causes server error upon launch

--- a/config/emacs/emacs_130s-t440s.el
+++ b/config/emacs/emacs_130s-t440s.el
@@ -1,8 +1,8 @@
 ; .emacs specific for 130s-t440s (Ubuntu Trusty)
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
 
 ;; Issue where texts are not shown with emacs -nw option is solved by using "when window-system"
 ;; https://www.emacswiki.org/emacs/FrameSize

--- a/config/emacs/emacs_130s-t440s_vm_ubuntu12.04.el
+++ b/config/emacs/emacs_130s-t440s_vm_ubuntu12.04.el
@@ -1,7 +1,7 @@
 ; .emacs specific for 130s-serval
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
 
 ; 4/6/2012/emacs tex live config
 (server-start)

--- a/config/emacs/emacs_130s-w510.el
+++ b/config/emacs/emacs_130s-w510.el
@@ -1,8 +1,8 @@
 ; .emacs specific for 130s-kudu1
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu_trusty.el")
 
 ;; mozc
 (require 'mozc)

--- a/config/emacs/emacs_btt.el
+++ b/config/emacs/emacs_btt.el
@@ -1,7 +1,7 @@
 ; .emacs specific for btt (desktop at Willow)
 
 ; 2/8/2013 Ubuntu common setting ported
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
 
 ; 4/6/2012/emacs tex live config
 (server-start)

--- a/config/emacs/emacs_ubuntu.el
+++ b/config/emacs/emacs_ubuntu.el
@@ -1,5 +1,5 @@
 ;; 6/9/2016 Common config read here.
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs.el")
 
 ;;20160429 Moved from downstream (kudu1, Trusty 14.04), hoping this is valid for all Ubuntu machines.
 ;; mozc

--- a/config/emacs/emacs_ubuntu_trusty.el
+++ b/config/emacs/emacs_ubuntu_trusty.el
@@ -1,6 +1,6 @@
 ; .emacs specific for Ubuntu Trusty
 
-(load "~/link/github_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
+(load "~/link/git_repos/130s/hut_10sqft/config/emacs/emacs_ubuntu.el")
 
 ;; Custom ROS location
 (set-register ?r '(file . "~/link/ROS/indigo_trusty/"))

--- a/script/install_ubuntu_common.sh
+++ b/script/install_ubuntu_common.sh
@@ -21,7 +21,7 @@ fi
 
 HOSTNAME=${1-"130s-serval"}
 RUN_TEST=${2-"false"}
-DIR_ACTUALHOSTS_LINK=link/github_repos/130s  # This is the arbitrary directory path that 130s likes to use to the folder of this package.
+DIR_ACTUALHOSTS_LINK=link/git_repos/130s  # This is the arbitrary directory path that 130s likes to use to the folder of this package.
 export MSG_ENDROLL=  # Set of messages to be echoed at the end.
 PKG_TO_INSTALL=""  # Initializing.
 USER_UBUNTU="n130s"
@@ -32,7 +32,7 @@ set -x
 echo "[DEBUG] ls: "; ls
 echo "[DEBUG] REPOSITORY_NAME=$REPOSITORY_NAME"
 mkdir -p ~/$DIR_ACTUALHOSTS_LINK
-ln -sf $CI_SOURCE_PATH ~/$DIR_ACTUALHOSTS_LINK/$REPOSITORY_NAME  # As a workaround an issue e.g. https://travis-ci.org/130s/hut_10sqft/jobs/131835176#L3951, enable to access files at /home/travis/link/github_repos/130s/hut_10sqft.
+ln -sf $CI_SOURCE_PATH ~/$DIR_ACTUALHOSTS_LINK/$REPOSITORY_NAME  # As a workaround an issue e.g. https://travis-ci.org/130s/hut_10sqft/jobs/131835176#L3951, enable to access files at /home/travis/link/git_repos/130s/hut_10sqft.
 
 #######################################
 # Default error handling method that should be used throughout the script. With this function the process exits.
@@ -263,7 +263,7 @@ if [ ! -d ~/data ]; then mkdir -p ~/data; fi
 if [ ! -d ~/link ]; then mkdir ~/link; fi
 cd link
 ln -sf ~/data/Dropbox/GoogleDrive/gm130s_other/Periodic/GooglePhotos/2017/ Current
-ln -sf ~/data/Dropbox/pg/myDevelopment/git_repo github_repos
+ln -sf ~/data/Dropbox/pg/myDevelopment/git_repo git_repos
 ln -sf ~/data/Dropbox/ROS .
 ln -sf ~/data/Dropbox/GoogleDrive/gm130s_other/30y-130s .
 ln -sf ~/data/Dropbox/GoogleDrive/gm130s_other/Academic/academicDoc .


### PR DESCRIPTION
Over time "`github`" has become not appropriate to cover what the folders in question do. Even "`git`" may not be good enough. It's probably "`repos`". But I've already applied the changes on multiple places with `git_repos`, so just go with it.