### PR TITLE
Improve chromeos emacs lang switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Emacs
+*~
+*#
+*.#*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - export CI_SOURCE_PATH="$TRAVIS_BUILD_DIR"
   matrix:
     - HOSTNAME=130s-kudu1
-    - HOSTNAME=130s-p50
+    - HOSTNAME=130s-p16s
     - HOSTNAME=130s-serval
     - HOSTNAME=130s-t440s
 install:

--- a/hut_10sqft/config/bash/bashrc_130s-p16s
+++ b/hut_10sqft/config/bash/bashrc_130s-p16s
@@ -1,2 +1,2 @@
 # This line needs to be absolute path.
-source ~/.config/hut_10sqft/config/bash/rc_130s-p50.bash
+source ~/.config/hut_10sqft/hut_10sqft/config/bash/rc_130s-p16s.bash

--- a/hut_10sqft/config/bash/rc_130s-p16s.bash
+++ b/hut_10sqft/config/bash/rc_130s-p16s.bash
@@ -2,4 +2,3 @@ DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source $DIR_THIS/rc_130s-serval.bash
 
-source $DIR_THIS/../ros/setup_ros_130s-p50.bash

--- a/hut_10sqft/config/emacs/emacs_130s-brya.el
+++ b/hut_10sqft/config/emacs/emacs_130s-brya.el
@@ -1,7 +1,7 @@
 ; .emacs specific for 130s-brya ChromeOS
 ; 20231123 Originally copied from emacs_130s-p16s.el
 
-(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs.el")
+(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs_chromeos.el")
 
 ;; Issue where texts are not shown with emacs -nw option is solved by using "when window-system"
 ;; https://www.emacswiki.org/emacs/FrameSize

--- a/hut_10sqft/config/emacs/emacs_chromeos.el
+++ b/hut_10sqft/config/emacs/emacs_chromeos.el
@@ -14,3 +14,14 @@
 ;;
 ;; The following, which is taken from an Emacs config on Linux, doesn't seem to work (likely because `toggle-input-method` doesn't work on ChromeOS?).
 ; (global-set-key (kbd "\C-q") 'toggle-input-method)
+
+;;20240117 Copied from ./emacs_ubuntu.el and modified hoping this works on ChromeOS. See https://github.com/kinu-garage/hut_10sqft/issues/983
+;; mozc
+(require 'mozc)
+; 2/15/2016 Without this, encoding may not be saved proerply?
+(set-language-environment "Japanese")
+(setq default-input-method "japanese-mozc")
+;;;(global-set-key (kbd "\C-o") 'toggle-input-method)  ; This doesn't seem to be working. Probably collides with OS' input key that is also \C-o ?
+(global-set-key (kbd "\C-q") 'toggle-input-method)
+; 20160609 Not sure how effective this is but I just leave it. https://wiki.archlinuxjp.org/index.php/Mozc#Emacs_.E3.81.A7_Mozc_.E3.82.92.E4.BD.BF.E3.81.86
+(setq mozc-candidate-style 'overlay)

--- a/hut_10sqft/executable/install_ubuntu_common.sh
+++ b/hut_10sqft/executable/install_ubuntu_common.sh
@@ -284,12 +284,12 @@ cd ~
 BASH_CONFIG_NAME=  # Initializing.
 EMACS_CONFIG_NAME=  # Initializing.
 case $HOSTNAME in
-    "130s-p50")
-	BASH_CONFIG_NAME="bashrc_130s-p50"
+    "130s-p16s")
+	BASH_CONFIG_NAME="bashrc_130s-p16s"
 	EMACS_CONFIG_NAME="emacs_130s-serval.el"
 
-        SSH_KEY_PRV="id_rsa_130s-p50"
-        SSH_KEY_PUB="id_rsa_130s-p50.pub"
+        SSH_KEY_PRV="id_rsa_130s-p16s"
+        SSH_KEY_PUB="id_rsa_130s-p16s.pub"
 	;;
     "130s-serval")
 	BASH_CONFIG_NAME="bashrc_130s-serval"

--- a/hut_10sqft/package.xml
+++ b/hut_10sqft/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>apt-transport-https</exec_depend>
   <exec_depend>ca-certificates</exec_depend>
   <exec_depend>emacs</exec_depend>
+  <exec_depend>emacs-mozc</exec_depend>
   <exec_depend>freecad</exec_depend>
   <exec_depend>gimp</exec_depend>
   <exec_depend>git</exec_depend>
@@ -23,6 +24,7 @@
   <exec_depend>meld</exec_depend>
   <exec_depend>mesa-utils</exec_depend>
   <exec_depend>meshlab</exec_depend>
+  <exec_depend>mozc-server</exec_depend>
   <exec_depend>ntp</exec_depend>
   <exec_depend>openjdk-7-jre</exec_depend>
   <exec_depend>python3-bloom</exec_depend>

--- a/hut_10sqft/src/hut_10sqft/init_setup.py
+++ b/hut_10sqft/src/hut_10sqft/init_setup.py
@@ -553,12 +553,7 @@ treats the user ID tha is used to execute this tool as the main user."""
         # Env vars per host: Bash, Emacs
         BASH_CONFIG_NAME =  ""
         EMACS_CONFIG_NAME = ""
-        if self._hostname == "130s-p50":
-            BASH_CONFIG_NAME = "bashrc_130s-p50"
-            EMACS_CONFIG_NAME = "emacs_130s-serval.el"
-            SSH_KEY_PRV = "id_rsa_130s-p50"
-            SSH_KEY_PUB = "id_rsa_130s-p50.pub"
-        elif self._hostname == "130s-p16s":
+        if self._hostname == "130s-p16s":
             BASH_CONFIG_NAME = "bashrc_130s-p16s"
             EMACS_CONFIG_NAME = "emacs_130s-p16s.el"
             SSH_KEY_PRV = "id_rsa_130s-p16s"


### PR DESCRIPTION
# Issues aimed at.
- https://github.com/kinu-garage/hut_10sqft/issues/983
- Obsolete hosts (esp. p50) are still supported.

# Resolution approach
- Install necessary pkgs for using `mozc`.
   - Upon https://github.com/kinu-garage/hut_10sqft/issues/983#issuecomment-1898102158 these were apparently missing.
- Use the same Emacs config for `mozc` that has been working on Ubuntu.
