### PR TITLE
Improve: Config for Bash, Emacs: Add a config for Debian OS that is a basis of ChromeOS' Linux and Ubuntu

### DIFF
--- a/hut_10sqft/config/bash/130s-brya.bash
+++ b/hut_10sqft/config/bash/130s-brya.bash
@@ -1,0 +1,2 @@
+# This line needs to be absolute path.
+source ~/.config/hut_10sqft/hut_10sqft/config/bash/rc_chromeos.bash

--- a/hut_10sqft/config/bash/rc_chromeos.bash
+++ b/hut_10sqft/config/bash/rc_chromeos.bash
@@ -1,6 +1,2 @@
 # This line needs to be absolute path.
 source ~/.config/hut_10sqft/hut_10sqft/config/bash/rc_debian.bash
-
-# 202401 Dumb solution to https://github.com/kinu-garage/hut_10sqft/issues/985#issuecomment-1911905752
-PATH="/usr/lib/mozc/:$PATH"
-alias mozc_conf_tool="mozc_tool --mode=config_dialog"

--- a/hut_10sqft/config/bash/rc_chromeos.bash
+++ b/hut_10sqft/config/bash/rc_chromeos.bash
@@ -1,0 +1,6 @@
+# This line needs to be absolute path.
+source ~/.config/hut_10sqft/hut_10sqft/config/bash/rc_debian.bash
+
+# 202401 Dumb solution to https://github.com/kinu-garage/hut_10sqft/issues/985#issuecomment-1911905752
+PATH="/usr/lib/mozc/:$PATH"
+alias mozc_conf_tool="mozc_tool --mode=config_dialog"

--- a/hut_10sqft/config/bash/rc_debian.bash
+++ b/hut_10sqft/config/bash/rc_debian.bash
@@ -36,3 +36,8 @@ export EDITOR=emacs
 
 # 20210518 Temp workaround(?) for pip install not adding binary to PATH. See https://gitlab.com/git-org/git-group/sub-group/-/merge_requests/71/diffs#note_577327855
 PATH="$HOME/.local/bin/:$PATH"
+
+# 202401 Dumb solution to https://github.com/kinu-garage/hut_10sqft/issues/985#issuecomment-1911905752
+# This should mostly be for non-GUI environmental (primarilly motivated for Linux mode in ChromeOS), but this might also be useful on GUI-powered but language manager doesn't start e.g. p16s Weyland
+PATH="/usr/lib/mozc/:$PATH"
+alias mozc_conf_tool="mozc_tool --mode=config_dialog"

--- a/hut_10sqft/config/bash/rc_debian.bash
+++ b/hut_10sqft/config/bash/rc_debian.bash
@@ -1,0 +1,38 @@
+## http://askubuntu.com/questions/21657/show-apt-get-installed-packages-history-via-commandline
+### pars for fun: install | remove | rollback
+function apt-history(){
+      case "$1" in
+        install)
+              cat /var/log/dpkg.log | grep 'install '
+              ;;
+        upgrade|remove)
+              cat /var/log/dpkg.log | grep $1
+              ;;
+        rollback)
+              cat /var/log/dpkg.log | grep upgrade | \
+                  grep "$2" -A10000000 | \
+                  grep "$3" -B10000000 | \
+                  awk '{print $4"="$5}'
+              ;;
+        *)
+              cat /var/log/dpkg.log
+              ;;
+      esac
+}
+
+DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR_THIS/bash_setup_common.bash
+
+# 20160716 git ssh issue https://github.com/130s/hut_10sqft/issues/64
+eval $(ssh-agent) >> /dev/null  # This doesn't complete the solution to https://github.com/130s/hut_10sqft/issues/64. In the downstream bash config, ssh-add needs to be run with the path of specific ssh key files.
+
+# For git
+export EDITOR=emacs
+
+# 20160716 git ssh issue https://github.com/130s/hut_10sqft/issues/64
+# Added in https://github.com/130s/hut_10sqft/pull/65
+# 20170916 To workaround https://github.com/130s/hut_10sqft/issues/67#issuecomment-330153887 upon scp, tentatively decided to comment this out. Each time accessing remote server that requires password (e.g. github.com), manually run ssh-add command (only once per terminal).
+#if [ -f ~/.ssh/id_rsa ]; then ssh-add ~/.ssh/id_rsa; fi  # Key is for github
+
+# 20210518 Temp workaround(?) for pip install not adding binary to PATH. See https://gitlab.com/git-org/git-group/sub-group/-/merge_requests/71/diffs#note_577327855
+PATH="$HOME/.local/bin/:$PATH"

--- a/hut_10sqft/config/bash/ubuntu_common.bash
+++ b/hut_10sqft/config/bash/ubuntu_common.bash
@@ -1,40 +1,4 @@
-## http://askubuntu.com/questions/21657/show-apt-get-installed-packages-history-via-commandline
-### pars for fun: install | remove | rollback
-function apt-history(){
-      case "$1" in
-        install)
-              cat /var/log/dpkg.log | grep 'install '
-              ;;
-        upgrade|remove)
-              cat /var/log/dpkg.log | grep $1
-              ;;
-        rollback)
-              cat /var/log/dpkg.log | grep upgrade | \
-                  grep "$2" -A10000000 | \
-                  grep "$3" -B10000000 | \
-                  awk '{print $4"="$5}'
-              ;;
-        *)
-              cat /var/log/dpkg.log
-              ;;
-      esac
-}
-
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $DIR_THIS/bash_setup_common.bash
+source $DIR_THIS/rc_debian.bash
 
 source $DIR_THIS/../ros/setup_ros_ubuntu_common.bash  # This uses env var DISTRO_ROS_LINUX.
-
-# 20160716 git ssh issue https://github.com/130s/hut_10sqft/issues/64
-eval $(ssh-agent) >> /dev/null  # This doesn't complete the solution to https://github.com/130s/hut_10sqft/issues/64. In the downstream bash config, ssh-add needs to be run with the path of specific ssh key files.
-
-# For git
-export EDITOR=emacs
-
-# 20160716 git ssh issue https://github.com/130s/hut_10sqft/issues/64
-# Added in https://github.com/130s/hut_10sqft/pull/65
-# 20170916 To workaround https://github.com/130s/hut_10sqft/issues/67#issuecomment-330153887 upon scp, tentatively decided to comment this out. Each time accessing remote server that requires password (e.g. github.com), manually run ssh-add command (only once per terminal).
-#if [ -f ~/.ssh/id_rsa ]; then ssh-add ~/.ssh/id_rsa; fi  # Key is for github
-
-# 20210518 Temp workaround(?) for pip install not adding binary to PATH. See https://gitlab.com/git-org/git-group/sub-group/-/merge_requests/71/diffs#note_577327855
-PATH="$HOME/.local/bin/:$PATH"

--- a/hut_10sqft/config/emacs/debian.el
+++ b/hut_10sqft/config/emacs/debian.el
@@ -1,0 +1,21 @@
+; .emacs specific for Debian OS
+; 20240125 Originally copied from emacs_chromeos.el
+; One example of Debian entity is Linux mode on ChromeOS, where paths are inevitably different from other Ubuntu hosts.
+
+(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs.el")
+
+;; Toggling OS language choice
+;;
+;; The following, which is taken from an Emacs config on Linux, doesn't seem to work (likely because `toggle-input-method` doesn't work on ChromeOS?).
+; (global-set-key (kbd "\C-q") 'toggle-input-method)
+
+;;20240117 Copied from ./emacs_ubuntu.el and modified hoping this works on ChromeOS. See https://github.com/kinu-garage/hut_10sqft/issues/983
+;; mozc
+(require 'mozc)
+; 2/15/2016 Without this, encoding may not be saved proerply?
+(set-language-environment "Japanese")
+(setq default-input-method "japanese-mozc")
+;;;(global-set-key (kbd "\C-o") 'toggle-input-method)  ; This doesn't seem to be working. Probably collides with OS' input key that is also \C-o ?
+(global-set-key (kbd "\C-q") 'toggle-input-method)
+; 20160609 Not sure how effective this is but I just leave it. https://wiki.archlinuxjp.org/index.php/Mozc#Emacs_.E3.81.A7_Mozc_.E3.82.92.E4.BD.BF.E3.81.86
+(setq mozc-candidate-style 'overlay)

--- a/hut_10sqft/config/emacs/emacs_chromeos.el
+++ b/hut_10sqft/config/emacs/emacs_chromeos.el
@@ -1,7 +1,7 @@
 ; .emacs specific for 130s-brya ChromeOS
 ; 20231123 Originally copied from emacs_130s-p16s.el
 
-(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs.el")
+(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/debian.el")
 
 ;; Creating short cut
 (set-register ?d '(file . "~/link/Current/"))
@@ -9,19 +9,3 @@
 ;; Emacs GUI default size
 ;; Determined by 130s-brya (13inch, 1920x1680). Can be re-defined in downstream if desired.
 (when window-system (set-frame-size (selected-frame) 88 34))
-
-;; Toggling OS language choice
-;;
-;; The following, which is taken from an Emacs config on Linux, doesn't seem to work (likely because `toggle-input-method` doesn't work on ChromeOS?).
-; (global-set-key (kbd "\C-q") 'toggle-input-method)
-
-;;20240117 Copied from ./emacs_ubuntu.el and modified hoping this works on ChromeOS. See https://github.com/kinu-garage/hut_10sqft/issues/983
-;; mozc
-(require 'mozc)
-; 2/15/2016 Without this, encoding may not be saved proerply?
-(set-language-environment "Japanese")
-(setq default-input-method "japanese-mozc")
-;;;(global-set-key (kbd "\C-o") 'toggle-input-method)  ; This doesn't seem to be working. Probably collides with OS' input key that is also \C-o ?
-(global-set-key (kbd "\C-q") 'toggle-input-method)
-; 20160609 Not sure how effective this is but I just leave it. https://wiki.archlinuxjp.org/index.php/Mozc#Emacs_.E3.81.A7_Mozc_.E3.82.92.E4.BD.BF.E3.81.86
-(setq mozc-candidate-style 'overlay)

--- a/hut_10sqft/config/emacs/emacs_ubuntu.el
+++ b/hut_10sqft/config/emacs/emacs_ubuntu.el
@@ -1,16 +1,5 @@
 ;; 6/9/2016 Common config read here.
-(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs.el")
-
-;;20160429 Moved from downstream (kudu1, Trusty 14.04), hoping this is valid for all Ubuntu machines.
-;; mozc
-(require 'mozc)
-; 2/15/2016 Without this, encoding may not be saved proerply?
-(set-language-environment "Japanese")
-(setq default-input-method "japanese-mozc")
-;;;(global-set-key (kbd "\C-o") 'toggle-input-method)  ; This doesn't seem to be working. Probably collides with OS' input key that is also \C-o ?
-(global-set-key (kbd "\C-q") 'toggle-input-method)
-; 20160609 Not sure how effective this is but I just leave it. https://wiki.archlinuxjp.org/index.php/Mozc#Emacs_.E3.81.A7_Mozc_.E3.82.92.E4.BD.BF.E3.81.86
-(setq mozc-candidate-style 'overlay)
+(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/debian.el")
 
 ; 6/30/2012/http://superuser.com/questions/165278/copying-text-from-emacs-into-other-programs
 (setq x-select-enable-clipboard t)      ;Make kill/yank work with the X clipboard


### PR DESCRIPTION
# Issue aimed at
- The exact same config for `mozc` on Emacs is duplicated in 2 files for Ubuntu and ChromeOS.
- Bash: Enable `mozc` GUI tool without a long convoluted command.

# Review
1. [ ] No obvious issue on Ubuntu (p16s)
1. [ ] No obvious issue on ChromeOS (brya)