### PR TITLE
Feat; bash path to `Unreal Engine` exec

### DIFF
--- a/hut_10sqft/config/bash/rc_130s-p16s.bash
+++ b/hut_10sqft/config/bash/rc_130s-p16s.bash
@@ -5,4 +5,5 @@ export DISTRO_ROS_LINUX=kinetic  # Folder name of ROS work spaces at ~/link/ROS/
 
 source $DIR_THIS/ubuntu_common.bash
 
-
+# 20241220 Unreal Engine https://github.com/kinu-garage/hut_10sqft/issues/861 this path is only available on p16s as of now.
+export PATH=~/pg/unreal-engine/UnrealEngine/Engine/Binaries/Linux/:$PATH

--- a/hut_10sqft/config/bash/rc_130s-p16s.bash
+++ b/hut_10sqft/config/bash/rc_130s-p16s.bash
@@ -1,4 +1,8 @@
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source $DIR_THIS/rc_130s-serval.bash
+export CMAKE_ECLIPSE_VERSION=4.4 # Eclipse Luner
+export DISTRO_ROS_LINUX=kinetic  # Folder name of ROS work spaces at ~/link/ROS/
+
+source $DIR_THIS/ubuntu_common.bash
+
 

--- a/hut_10sqft/config/bash/rc_130s-serval.bash
+++ b/hut_10sqft/config/bash/rc_130s-serval.bash
@@ -1,8 +1,0 @@
-DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-export CMAKE_ECLIPSE_VERSION=4.4 # Eclipse Luner
-export DISTRO_ROS_LINUX=kinetic  # Folder name of ROS work spaces at ~/link/ROS/
-
-source $DIR_THIS/ubuntu_common.bash
-
-source $DIR_THIS/../ros/setup_ros_serval.bash

--- a/hut_10sqft/config/emacs/debian.el
+++ b/hut_10sqft/config/emacs/debian.el
@@ -19,3 +19,6 @@
 (global-set-key (kbd "\C-q") 'toggle-input-method)
 ; 20160609 Not sure how effective this is but I just leave it. https://wiki.archlinuxjp.org/index.php/Mozc#Emacs_.E3.81.A7_Mozc_.E3.82.92.E4.BD.BF.E3.81.86
 (setq mozc-candidate-style 'overlay)
+
+; 20241230 Following the decision https://github.com/kinu-garage/essay_in_idleness/issues/306#issuecomment-2514215071, "~/link/Current" should be available on all of my Debian (incl. ChromeOS' Linux mode) and Ubuntu hosts.
+(set-register ?d '(file . "~/link/Current/"))  ; See https://github.com/kinu-garage/essay_in_idleness/issues/306

--- a/hut_10sqft/config/emacs/emacs_ubuntu.el
+++ b/hut_10sqft/config/emacs/emacs_ubuntu.el
@@ -27,5 +27,4 @@
 (put 'upcase-region 'disabled nil)
 
 ;; Creating short cut
-(set-register ?d '(file . "~/link/Current/"))  ; See https://github.com/kinu-garage/essay_in_idleness/issues/306
 (set-register ?s '(file . "~/data/Dropbox/app/Synergy/"))

--- a/hut_10sqft/config/ros/setup_ros_serval.bash
+++ b/hut_10sqft/config/ros/setup_ros_serval.bash
@@ -1,3 +1,0 @@
-DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-


### PR DESCRIPTION
# Issues aimed at
- `serval` is no longer serving so its configs are only confusing https://github.com/kinu-garage/hut_10sqft/issues/826
-  Executable of `Unreal Engine` is hard to type in every time.
- SUCO; Fix missing shortcut directory on Emacs after https://github.com/kinu-garage/essay_in_idleness/issues/306#issuecomment-2514215071