### PR TITLE
Fix; SUCO: 1) venv needed earlier. 2) Typo. 3) Outdated argument

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false  # Allows other jobs in the matrix to continue if one fails
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-24.04, macos-14]
 #        os: [debian-11, ubuntu-24.04, macos-11]
     runs-on: ${{ matrix.os }}
 

--- a/hut_10sqft/doc/index.md
+++ b/hut_10sqft/doc/index.md
@@ -23,8 +23,8 @@ Prerequisite:
      export OS_DiSTRO=Ubuntu &&  \
      source $PATH_TMP_WS/install/setup.bash && \
      cd $PATH_TMP_WS/src/hut_10sqft/hut_10sqft && python -m pip install setuptools && python setup.py install && cd $PATH_TMP_WS
-   $ suco --hostname $HOST_NAME --os_distro $OS_DISTRO --conf_repo_version $VERSION && \
-     echo "Removing a temp colcon ws dir".; rm -fr $PATH_TMP_WS
+   $ suco --hostname $HOST_NAME --os_distro $OS_DISTRO --conf_repo_version $VERSION
+   $ echo "Removing a temp colcon ws dir".; rm -fr $PATH_TMP_WS
    ```
    Note as of v0.3.1, when re-running SUCO, running the whole set of lines, instead of resuming at certain line in the middle, is recommended.
 

--- a/hut_10sqft/doc/index.md
+++ b/hut_10sqft/doc/index.md
@@ -11,10 +11,11 @@ Prerequisite:
    ```
    $ export PATH_TMP_SUCO=~/.local/share/tmp_suco && \
      export PATH_VENV=~/.local/share/tmp_suco/venv && \
+     sudo apt update && sudo apt install python3-venv && \
      mkdir -p $PATH_TMP_SUCO && cd $PATH_TMP_SUCO && python3 -m venv $PATH_VENV && source $PATH_VENV/bin/activate
    $ export SUCO_INSTALLER=/tmp/suco.py &&  \
      export VERSION=0.3.0 &&  \
-     sudo apt update && sudo apt install -y curl git python3 python3-venv python3-pip &&  \
+     sudo apt update && sudo apt install -y curl git python3 python3-pip &&  \
      curl --output $SUCO_INSTALLER https://raw.githubusercontent.com/kinu-garage/hut_10sqft/$VERSION/hut_10sqft/hut_10sqft/suco_installer.py && chmod 755 $SUCO_INSTALLER && \
      export GIT_CONFIG_GLOBAL=''; export GIT_CONFIG_SYSTEM=''; $SUCO_INSTALLER --git_branch $VERSION
    $ export PATH_TMP_WS=~/.local/share/tmp_suco/colconws &&  \
@@ -22,7 +23,7 @@ Prerequisite:
      export OS_DiSTRO=Ubuntu &&  \
      source $PATH_TMP_WS/install/setup.bash && \
      cd $PATH_TMP_WS/src/hut_10sqft/hut_10sqft && python -m pip install setuptools && python setup.py install && cd $PATH_TMP_WS
-   $ suco --hostname $HOST_NAME --os_distro $OS_DiSTRO --conf_repo_version $VERSION && \
+   $ suco --hostname $HOST_NAME --os_distro $OS_DISTRO --conf_repo_version $VERSION && \
      echo "Removing a temp colcon ws dir".; rm -fr $PATH_TMP_WS
    ```
    Note as of v0.3.1, when re-running SUCO, running the whole set of lines, instead of resuming at certain line in the middle, is recommended.
@@ -30,7 +31,7 @@ Prerequisite:
    Customization:
    - `VERSION`: if you want to use non-standard branch/version.
    - `HOST_NAME`: Must be already defined in the code (e.g. 130s-p16s). Otherwise execution fails.
-   - `OSTYPE` Must be already defined in the code. Currently available options: [`ChromeOS` | `Debian` | `Ubuntu`]
+   - `OS_DISTRO`: Must be already defined in the code. Currently available options: [`ChromeOS` | `Debian` | `Ubuntu`]
 1. At the end of the execution of the above command you should see the list of runtime issues that are captured during the run. Address those if possible.
 1. Should be ready to start using the OS.
 


### PR DESCRIPTION
# Issues targeted
- Closes https://github.com/kinu-garage/hut_10sqft/issues/1359
- Runtime failure on Debian on ChromeOS (found on c14-morph) reported at https://github.com/kinu-garage/hut_10sqft/pull/1365#issuecomment-3782093204
- Missing command e.g. `convert` (that should be provided by one of a pkg in rosdep keys (imagemagick)
