### PR TITLE
1) feat(.gitconfig); Allow `https` remote host along with `ssh`. 2) Add msze36 host conf, added a few custom lines Gemini suggested

### DIFF
--- a/hut_10sqft/config/dot_gitconfig
+++ b/hut_10sqft/config/dot_gitconfig
@@ -14,11 +14,17 @@
 # Always use ssh for github, even if the remote URL uses https or git
 [url "git@github.com:"]
         insteadOf = git://github.com/
-[url "git@github.com:"]
-        insteadOf = https://github.com/
+# 20260528 Re-enable https. See https://github.com/kinu-garage/hut_10sqft/issues/1444
+##[url "git@github.com:"]
+##        insteadOf = https://github.com/
 [fetch]
 	prune = true
 [url "git@gitlab.com:"]
 	insteadOf = https://gitlab.com/
 [init]
 	defaultBranch = develop
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true

--- a/hut_10sqft/config/emacs/emacs_closer-MSZE36.el
+++ b/hut_10sqft/config/emacs/emacs_closer-MSZE36.el
@@ -1,0 +1,8 @@
+; .emacs specific for closer-MSZE36.el (originally based off of 130s-p16s)
+
+;; Load setup for a dev Ubuntu host.
+(load "~/.config/hut_10sqft/hut_10sqft/config/emacs/emacs_130s-p16s.el")
+
+;; 20260325 debug https://github.com/kinu-garage/hut_10sqft/issues/1411 suggested by Gemini
+(tooltip-mode -1)
+(setq use-gtk-tooltip nil)


### PR DESCRIPTION
# Issues tagted
- May fix Emacs crashing https://github.com/kinu-garage/hut_10sqft/issues/1411
- Closes https://github.com/kinu-garage/hut_10sqft/issues/1444