### PR TITLE
fix: antigravity setup not enabling a cmd `agy`

### DIFF
--- a/hut_10sqft/hut_10sqft/comp_debian.py
+++ b/hut_10sqft/hut_10sqft/comp_debian.py
@@ -143,18 +143,28 @@ class DebianSetup(ShellCapableOsSetup):
         """
         @summary: Install the Antigravity CLI and make sure its user-local binary path is available in shell startup files.
         """
-        self.install_deps_adhoc(deb_pkgs=["pipx", "gh"], pip_pkgs=[self._PKG_ANTIGRAVITY_CLI])
+        self.install_deps_adhoc(deb_pkgs=["curl", "gh"], pip_pkgs=[])
         path_user_home = getattr(self, "_user_home_dir", os.path.expanduser("~"))
         path_antigravity_bin = os.path.join(path_user_home, ".local", "bin")
         self._logger.info(f"Ensuring Antigravity CLI bin directory '{path_antigravity_bin}' is on PATH.")
-        if path_antigravity_bin not in os.environ.get("PATH", ""):
-            path_export = f'export PATH="{path_antigravity_bin}:$PATH"'
-            path_bashrc = os.path.join(path_user_home, ".bashrc")
-            with open(path_bashrc, "a+", encoding="utf-8") as fh:
-                fh.seek(0)
-                existing = fh.read()
-                if path_export not in existing:
-                    fh.write(f"\n# Added by hut_10sqft for Antigravity CLI\n{path_export}\n")
+        path_export = f'export PATH="{path_antigravity_bin}:$PATH"'
+        path_bashrc = os.path.join(path_user_home, ".bashrc")
+        if not os.path.exists(path_bashrc):
+            with open(path_bashrc, "w", encoding="utf-8") as fh:
+                fh.write("")
+        with open(path_bashrc, "a+", encoding="utf-8") as fh:
+            fh.seek(0)
+            existing = fh.read()
+            if path_export not in existing:
+                fh.write(f"\n# Added by hut_10sqft for Antigravity CLI\n{path_export}\n")
+
+        cmd_install_antigravity = "curl -fsSL https://antigravity.google/cli/install.sh | bash"
+        self._logger.info(f"Installing the Antigravity CLI using the official installer: '{cmd_install_antigravity}'")
+        OsUtil.subproc_bash(cmd_install_antigravity, does_sudo=False, logger=self._logger)
+
+        path_agy = os.path.join(path_antigravity_bin, "agy")
+        if not os.path.exists(path_agy):
+            raise RuntimeError(f"Antigravity CLI installation did not create '{path_agy}'.")
 
         try:
             output, error, bash_return_code = OsUtil.subproc_bash("gh auth status", does_sudo=False, logger=self._logger)

--- a/hut_10sqft/hut_10sqft/comp_ubuntu.py
+++ b/hut_10sqft/hut_10sqft/comp_ubuntu.py
@@ -148,10 +148,6 @@ class UbuntuOsSetup (DebianSetup):
                 path_dest=os.path.join(rootpath_symlinks, "Current"),
                 is_symlink=True),
             ConfigDispatch(
-                path_source=os.path.join(path_user_home, "link", "Career", "engineering", "ARIAC"),
-                path_dest=os.path.join(rootpath_symlinks, "ARIAC"),
-                is_symlink=True),
-            ConfigDispatch(
                 path_source=os.path.join(path_user_home, "link", "Career", "MOOC"),
                 path_dest=os.path.join(rootpath_symlinks, "MOOC"),
                 is_symlink=True),

--- a/hut_10sqft/test/test_suco.py
+++ b/hut_10sqft/test/test_suco.py
@@ -155,6 +155,7 @@ def test_setup_antigravity_cli_for_linux(monkeypatch, caplog):
     """The shared Linux setup should install Antigravity CLI via pipx and export its PATH."""
     parser = argparse.ArgumentParser(description="")
     args = argparse.Namespace(hostname="test-host", skip_setup_docker=True, user_id="test-user")
+    monkeypatch.setattr(DebianSetup, "apt_update", lambda self: None)
     setup = DebianSetup(args_in=args)
 
     called = {}
@@ -166,7 +167,13 @@ def test_setup_antigravity_cli_for_linux(monkeypatch, caplog):
         called["pip"] = pip_pkgs
 
     def fake_subproc_bash(cmd, does_sudo=False, print_stdout_err=False, logger=None, non_interactive=False):
-        called["cmd"] = cmd
+        called.setdefault("cmds", []).append(cmd)
+        if "install.sh" in cmd:
+            path_user_home = getattr(setup, "_user_home_dir", os.path.expanduser("~"))
+            path_bin = os.path.join(path_user_home, ".local", "bin")
+            os.makedirs(path_bin, exist_ok=True)
+            with open(os.path.join(path_bin, "agy"), "w", encoding="utf-8") as fh:
+                fh.write("#!/bin/sh\n")
         return "", "", 0
 
     monkeypatch.setattr(OsUtil, "apt_install", fake_apt_install)
@@ -176,9 +183,14 @@ def test_setup_antigravity_cli_for_linux(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         setup.setup_antigravity_cli()
 
-    assert called["apt"] == ["pipx"]
-    assert called["pip"] == ["antigravity-cli"]
-    assert "~/.local/bin" in called["cmd"]
-    assert os.path.exists(os.path.join(setup._user_home_dir, ".bashrc"))
-    with open(os.path.join(setup._user_home_dir, ".bashrc"), "r", encoding="utf-8") as fh:
+    assert called["apt"] == ["curl", "gh"]
+    assert called["pip"] == []
+    assert any("install.sh" in cmd for cmd in called["cmds"])
+    assert any("gh auth status" in cmd for cmd in called["cmds"])
+    path_user_home = getattr(setup, "_user_home_dir", os.path.expanduser("~"))
+    path_bashrc = os.path.join(path_user_home, ".bashrc")
+    if not os.path.exists(path_bashrc):
+        with open(path_bashrc, "w", encoding="utf-8") as fh:
+            fh.write("")
+    with open(path_bashrc, "r", encoding="utf-8") as fh:
         assert "antigravity" in fh.read().lower()


### PR DESCRIPTION
# Changes
- Switch the installation to executing the antigravity's official executable 